### PR TITLE
[FIX] Prevent leak of Skycons instances.

### DIFF
--- a/src/react-skycons.js
+++ b/src/react-skycons.js
@@ -44,6 +44,10 @@ const ReactSkycons = React.createClass({
    this.state.skycons.set(React.findDOMNode(this), Skycons[nextProps.icon]);
   },
 
+  componentWillUnmount: function componentWillUnmount() {
+    this.state.skycons.pause();
+    this.state.skycons.remove(React.findDOMNode(this));
+  },
 
   play() {
     this.state.skycons.play();


### PR DESCRIPTION
By not destroying Skycons instances on component unmount, we were
allowing them accumulate in long-running apps that create/destroy
instances in cycles.

Tested in https://github.com/mojotech/helios, and this appeared
to alleviate the issue.
