### PR TITLE
add lowercase icon names

### DIFF
--- a/src/ReactSkycons.js
+++ b/src/ReactSkycons.js
@@ -46,7 +46,10 @@ export default class ReactSkycons extends React.Component {
 
   componentDidMount() {
     const { skycons } = this.state;
-    skycons.add(ReactDOM.findDOMNode(this), Skycons[this.props.icon]);
+    skycons.add(
+      ReactDOM.findDOMNode(this),
+      Skycons[this.props.icon.toUpperCase().replace("-", "_")]
+    );
 
     if (this.props.autoplay) {
       skycons.play();

--- a/src/ReactSkycons.js
+++ b/src/ReactSkycons.js
@@ -1,23 +1,33 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import ReactDOM from 'react-dom'
-const Skycons = require('skycons')(window)
+import React from "react";
+import PropTypes from "prop-types";
+import ReactDOM from "react-dom";
+const Skycons = require("skycons")(window);
 
 export default class ReactSkycons extends React.Component {
   static propTypes = {
     color: PropTypes.string,
     autoplay: PropTypes.bool,
     icon: PropTypes.oneOf([
-      'CLEAR_DAY',
-      'CLEAR_NIGHT',
-      'PARTLY_CLOUDY_DAY',
-      'PARTLY_CLOUDY_NIGHT',
-      'CLOUDY',
-      'RAIN',
-      'SLEET',
-      'SNOW',
-      'WIND',
-      'FOG'
+      "CLEAR_DAY",
+      "CLEAR_NIGHT",
+      "PARTLY_CLOUDY_DAY",
+      "PARTLY_CLOUDY_NIGHT",
+      "CLOUDY",
+      "RAIN",
+      "SLEET",
+      "SNOW",
+      "WIND",
+      "FOG",
+      "clear-day",
+      "clear-night",
+      "partly-cloudy-day",
+      "partly-cloudy-night",
+      "cloudy",
+      "rain",
+      "sleet",
+      "snow",
+      "wind",
+      "fog"
     ])
   };
 
@@ -26,42 +36,42 @@ export default class ReactSkycons extends React.Component {
     autoplay: true
   };
 
-  constructor (props) {
-    super(props)
+  constructor(props) {
+    super(props);
 
     this.state = {
-      skycons: new Skycons({ 'color': this.props.color })
-    }
+      skycons: new Skycons({ color: this.props.color })
+    };
   }
 
-  componentDidMount () {
-    const { skycons } = this.state
-    skycons.add(ReactDOM.findDOMNode(this), Skycons[this.props.icon])
+  componentDidMount() {
+    const { skycons } = this.state;
+    skycons.add(ReactDOM.findDOMNode(this), Skycons[this.props.icon]);
 
     if (this.props.autoplay) {
-      skycons.play()
+      skycons.play();
     }
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.state.skycons.set(ReactDOM.findDOMNode(this), Skycons[nextProps.icon])
+  componentWillReceiveProps(nextProps) {
+    this.state.skycons.set(ReactDOM.findDOMNode(this), Skycons[nextProps.icon]);
   }
 
-  componentWillUnmount () {
-    const { skycons } = this.state
-    skycons.pause()
-    skycons.remove(ReactDOM.findDOMNode(this))
+  componentWillUnmount() {
+    const { skycons } = this.state;
+    skycons.pause();
+    skycons.remove(ReactDOM.findDOMNode(this));
   }
 
-  play () {
-    this.state.skycons.play()
+  play() {
+    this.state.skycons.play();
   }
 
-  pause () {
-    this.state.skycons.pause()
+  pause() {
+    this.state.skycons.pause();
   }
 
-  render () {
+  render() {
     const {
       /* eslint-disable */
       // to remove unnecessary props
@@ -70,15 +80,13 @@ export default class ReactSkycons extends React.Component {
       icon,
       /* eslint-enable */
       ...restPops
-    } = this.props
+    } = this.props;
 
     const defaultStyle = {
-      width: '100%',
-      height: '100%'
-    }
+      width: "100%",
+      height: "100%"
+    };
 
-    return (
-      <canvas style={defaultStyle} {...restPops} />
-    )
+    return <canvas style={defaultStyle} {...restPops} />;
   }
 }

--- a/src/ReactSkycons.js
+++ b/src/ReactSkycons.js
@@ -57,7 +57,10 @@ export default class ReactSkycons extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.state.skycons.set(ReactDOM.findDOMNode(this), Skycons[nextProps.icon]);
+    this.state.skycons.set(
+      ReactDOM.findDOMNode(this),
+      Skycons[nextProps.icon.toUpperCase().replace("-", "_")]
+    );
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
DarkSky API returns icon in lowercase.

https://darksky.net/dev/docs
![dark_sky_api__documentation_overview](https://user-images.githubusercontent.com/809378/39854100-0a7d8ff8-5461-11e8-9023-4439f8fdb4b6.png)

Having the same icon names will be easier to apply the icon prop.

```js

// results is the data came from DarkSky api

<Skycons 
        color='white' 
        icon={results.icon}
        autoplay={false}
      />
```